### PR TITLE
Migrate to null safety

### DIFF
--- a/lib/brushes/lasso.dart
+++ b/lib/brushes/lasso.dart
@@ -16,7 +16,7 @@ class LassoBrush extends PolygonTool {
 
 class LassoPath extends ToolPath {
   int minDistance = 4;
-  Polygon polygon;
+  late Polygon _polygon;
   int _safelySimple = 0;
 
   LassoPath(PolyMaker maker, PolygonTool brush) : super(maker, brush) {
@@ -26,12 +26,12 @@ class LassoPath extends ToolPath {
 
   @override
   void handleStart(Point<int> p) {
-    polygon = maker.newPoly([p]);
+    _polygon = maker.newPoly([p]);
   }
 
   @override
   void handleMouseMove(Point<int> p) {
-    if (maker.isClicked) return maker.updatePreview([...polygon.points, p]);
+    if (maker.isClicked) return maker.updatePreview([..._polygon.points, p]);
 
     _addSinglePoint(p, updatePreview: true);
   }
@@ -47,29 +47,29 @@ class LassoPath extends ToolPath {
   }
 
   void _addSinglePoint(Point<int> p, {bool updatePreview = false}) {
-    if (p.squaredDistanceTo(polygon.points.last) > minDistance) {
-      polygon.points.add(p);
+    if (p.squaredDistanceTo(_polygon.points.last) > minDistance) {
+      _polygon.points.add(p);
       if (updatePreview) {
-        maker.updatePreview(polygon.points);
+        maker.updatePreview(_polygon.points);
       }
     }
   }
 
   @override
-  bool isValid([Point<int> extraPoint]) =>
+  bool isValid([Point<int>? extraPoint]) =>
       isSimple(maker.isClicked ? extraPoint : null);
 
   /// Returns true if this polygon (+ `extraPoint`) doesn't intersect itself.
-  bool isSimple([Point<int> extraPoint]) {
-    if (polygon.points.length < 3) return true;
+  bool isSimple([Point<int>? extraPoint]) {
+    if (_polygon.points.length < 3) return true;
 
-    var nvert = polygon.points.length;
+    var nvert = _polygon.points.length;
 
     if (extraPoint != null) nvert++;
 
     Point<int> elem(int i) => (extraPoint != null && i % nvert == nvert - 1)
         ? extraPoint
-        : polygon.points[i % nvert];
+        : _polygon.points[i % nvert];
 
     for (var i = _safelySimple; i < nvert; i++) {
       var u = elem(i);

--- a/lib/brushes/stroke.dart
+++ b/lib/brushes/stroke.dart
@@ -15,8 +15,8 @@ final unitSquare = AngleShape(_squarePoints, _squareAngles);
 class StrokeBrush extends PolygonTool {
   static const toolId = 'stroke';
 
-  AngleShape _shape;
-  String _shapeId;
+  late AngleShape _shape;
+  late String _shapeId;
   String get shape => _shapeId;
   set shape(String shapeId) {
     _shapeId = shapeId;
@@ -26,9 +26,9 @@ class StrokeBrush extends PolygonTool {
   double radius = 2;
   double get radiusScaled => exp(radius) * 8;
 
-  Point<int> _bufferP;
+  Point<int>? _bufferP;
   double _bufferRadius = -1;
-  List<Point<int>> _bufferOutline;
+  List<Point<int>>? _bufferOutline;
 
   StrokeBrush() : super(toolId, employMouseWheel: true) {
     shape = shapeCircle;
@@ -38,8 +38,8 @@ class StrokeBrush extends PolygonTool {
   ToolPath createNewPath(PolyMaker maker) => StrokePath(maker, this);
 
   @override
-  List<Point<int>> drawCursor(Point<int> p, [List<Point<int>> override]) {
-    if (p == _bufferP && radius == _bufferRadius) return _bufferOutline;
+  List<Point<int>> drawCursor(Point<int> p, [List<Point<int>>? override]) {
+    if (p == _bufferP && radius == _bufferRadius) return _bufferOutline!;
 
     _bufferP = p;
     _bufferRadius = radius;
@@ -48,7 +48,7 @@ class StrokeBrush extends PolygonTool {
   }
 
   @override
-  bool handleMouseWheel(int amount) {
+  bool handleMouseWheel(num amount) {
     final nRadius = radius - 0.2 * amount;
     if (nRadius <= 0) return false;
 
@@ -63,7 +63,8 @@ class StrokeBrush extends PolygonTool {
       case shapeSquare:
         return unitSquare;
     }
-    return null;
+
+    throw 'Unknown shape ${shapeId}';
   }
 
   @override
@@ -81,8 +82,8 @@ class StrokeBrush extends PolygonTool {
 
 class StrokePath extends ToolPath<StrokeBrush> {
   int minDistance = 10;
-  Point<int> last;
-  AngleShape circle;
+  Point<int>? last;
+  late AngleShape<int> circle;
 
   StrokePath(PolyMaker maker, StrokeBrush brush) : super(maker, brush) {
     final unsquared = (minDistance * maker.movementScale);
@@ -100,7 +101,8 @@ class StrokePath extends ToolPath<StrokeBrush> {
   void handleMouseMove(Point<int> p) {
     circle = makeAngleShape(tool._shape, p, tool.radiusScaled);
     maker.updatePreview(tool.drawCursor(p, circle.points));
-    if (p.squaredDistanceTo(last) > minDistance) {
+
+    if (p.squaredDistanceTo(last!) > minDistance) {
       _update(p);
     }
   }

--- a/lib/brushes/tool.dart
+++ b/lib/brushes/tool.dart
@@ -15,7 +15,7 @@ abstract class PolygonTool {
 
   ToolPath createNewPath(PolyMaker maker);
   List<Point<int>> drawCursor(Point<int> p) => [p];
-  bool handleMouseWheel(int amount) => false;
+  bool handleMouseWheel(num amount) => false;
 
   Map<String, dynamic> toJson() => const {};
   void fromJson(Map<String, dynamic> json) {}
@@ -31,7 +31,7 @@ abstract class ToolPath<T extends PolygonTool> {
   void handleMouseMove(Point<int> p);
   void handleMouseClick(Point<int> p) {}
   void handleEnd(Point<int> p) {}
-  bool isValid([Point<int> extra]) => true;
+  bool isValid([Point<int>? extra]) => true;
 }
 
 class PolyMaker {

--- a/lib/brushes/toolbox.dart
+++ b/lib/brushes/toolbox.dart
@@ -6,15 +6,13 @@ mixin PolygonToolbox {
   final toolBrushStroke = StrokeBrush();
   final toolBrushLasso = LassoBrush();
 
-  Map<String, PolygonTool> _toolMap;
-  Map<String, PolygonTool> get toolMap =>
-      _toolMap ??
-      {
+  Map<String, PolygonTool>? _toolMap;
+  Map<String, PolygonTool> get toolMap => _toolMap ??= {
         toolBrushStroke.id: toolBrushStroke,
         toolBrushLasso.id: toolBrushLasso,
       };
 
-  PolygonTool _activeTool;
+  PolygonTool? _activeTool;
   PolygonTool get activeTool => _activeTool ??= toolBrushStroke;
   set activeTool(PolygonTool tool) {
     _activeTool = tool;

--- a/lib/interactive/svg_polygon.dart
+++ b/lib/interactive/svg_polygon.dart
@@ -7,7 +7,7 @@ class SvgPolygon {
   final Polygon polygon;
   final svg.PolygonElement _el;
 
-  String get currentSvgData => _el.getAttribute('points');
+  String get currentSvgData => _el.getAttribute('points') ?? '';
 
   SvgPolygon(Element parent, this.polygon) : _el = svg.PolygonElement() {
     refreshSvg();
@@ -16,7 +16,7 @@ class SvgPolygon {
 
   SvgPolygon.from(
     Element parent, {
-    List<Point<int>> points,
+    List<Point<int>>? points,
     bool positive = true,
   }) : this(parent, Polygon(points: points, positive: positive));
 
@@ -28,8 +28,8 @@ class SvgPolygon {
     _el.remove();
   }
 
-  void refreshSvg([Point<int> extraPoint]) =>
+  void refreshSvg([Point<int>? extraPoint]) =>
       _el.setAttribute('points', polygon.toSvgData(extraPoint));
 
-  SvgPolygon copy() => SvgPolygon(_el.parent, polygon.copy());
+  SvgPolygon copy() => SvgPolygon(_el.parent!, polygon.copy());
 }

--- a/lib/math/polygon.dart
+++ b/lib/math/polygon.dart
@@ -6,17 +6,17 @@ class Polygon {
   final bool positive;
 
   bool _boxUpToDate = false;
-  Rectangle<int> _boundingBox;
+  Rectangle<int>? _boundingBox;
   Rectangle<int> get boundingBox {
     if (!_boxUpToDate) {
       _boundingBox = pointsToBoundingBox(points);
       _boxUpToDate = true;
     }
 
-    return _boundingBox;
+    return _boundingBox!;
   }
 
-  Polygon({List<Point<int>> points, this.positive = true})
+  Polygon({List<Point<int>>? points, this.positive = true})
       : points = points ?? [];
 
   static Polygon fromRect(Rectangle<int> rect, {bool positive = true}) {
@@ -51,7 +51,7 @@ class Polygon {
   }
 
   /// Determines if this polygon intersects itself.
-  bool isSimple([Point<int> extraPoint]) {
+  bool isSimple([Point<int>? extraPoint]) {
     if (points.length < 3) return true;
 
     var nvert = points.length;
@@ -112,11 +112,11 @@ class Polygon {
     return false;
   }
 
-  String toSvgData([Point<int> extraPoint]) {
+  String toSvgData([Point<int>? extraPoint]) {
     return pointsToSvg(extraPoint == null ? points : [...points, extraPoint]);
   }
 
-  Polygon copy({bool positive}) =>
+  Polygon copy({bool? positive}) =>
       Polygon(points: points.toList(), positive: positive ?? this.positive);
 
   @override

--- a/lib/math/polygon_state.dart
+++ b/lib/math/polygon_state.dart
@@ -1,7 +1,7 @@
 import 'polygon.dart';
 
 class PolygonState {
-  final Map<Polygon, Polygon> parents;
+  final Map<Polygon, Polygon?> parents;
 
   PolygonState(this.parents);
 
@@ -12,7 +12,9 @@ class PolygonState {
       for (var other in state) {
         if (other.positive != poly.positive) {
           if (other.contains(poly)) {
-            if (parents[poly] == null || parents[poly].contains(other)) {
+            final polyParent = parents[poly];
+
+            if (polyParent == null || polyParent.contains(other)) {
               parents[poly] = other;
             }
           }
@@ -30,7 +32,7 @@ class PolygonState {
     }
   }
 
-  void _assignParent(HPolygon poly, Polygon parent) {
+  void _assignParent(HPolygon poly, Polygon? parent) {
     parents[poly.polygon] = parent;
     for (var child in poly.children) {
       _assignParent(child, poly.polygon);
@@ -39,11 +41,14 @@ class PolygonState {
 
   bool isValid({bool checkSimplicity = false}) {
     if (!parents.entries.every((e) {
+      final polygon = e.key;
+      final parent = e.value;
+
       // Roots must be positive
-      if (e.value == null) return e.key.positive;
+      if (parent == null) return e.key.positive;
 
       // Parents must be of oppositive pole and fully contain their children.
-      return e.key.positive != e.value.positive && e.value.contains(e.key);
+      return polygon.positive != parent.positive && parent.contains(polygon);
     })) return false;
 
     if (checkSimplicity) {
@@ -62,7 +67,7 @@ class PolygonState {
       if (parent == null) {
         root.add(c.value);
       } else {
-        conv[parent].children.add(c.value);
+        conv[parent]!.children.add(c.value);
       }
     }
 

--- a/lib/math/polymath.dart
+++ b/lib/math/polymath.dart
@@ -388,7 +388,7 @@ OperationResult _operation(Polygon? a, Polygon? b, bool union) {
 
 extension NullIterableExtension<T> on Iterable<T?> {
   Iterable<T> get withoutNulls =>
-      this.where((element) => element != null) as Iterable<T>;
+      this.where((e) => e != null).map((e) => e as T);
 }
 
 void _dilate(

--- a/lib/math/polymath.dart
+++ b/lib/math/polymath.dart
@@ -41,7 +41,7 @@ bool boxOverlap(Polygon a, Polygon b) {
 ///
 /// Based on André LaMothe's algorithm, as
 /// presented on [stackoverflow](https://stackoverflow.com/a/1968345).
-Point<double> segmentIntersect(Point a, Point b, Point u, Point v,
+Point<double>? segmentIntersect(Point a, Point b, Point u, Point v,
     {bool includeEnds = true}) {
   if (!segmentRoughIntersect(a, b, u, v)) return null;
 
@@ -181,9 +181,9 @@ const double _noiseA = 2.8710980267e-05;
 /// When compared to existing polygon clipping algorithms, the
 /// [Greiner-Hormann algorithm](https://dl.acm.org/doi/10.1145/274363.274364)
 /// seems to be very similar to what I've come up with.
-OperationResult _operation(Polygon a, Polygon b, bool union) {
+OperationResult _operation(Polygon? a, Polygon? b, bool union) {
   if (a == null && b == null) return OperationResultAbort(const []);
-  if (identical(a, b) || b == null) return OperationResultAbort([a]);
+  if (identical(a, b) || b == null) return OperationResultAbort([a!]);
   if (a == null) return OperationResultAbort([b]);
 
   if (!a.boundingBox.intersects(b.boundingBox)) {
@@ -357,7 +357,7 @@ OperationResult _operation(Polygon a, Polygon b, bool union) {
     var bigBox = pointsToBoundingBox(results.first);
     var firstIsPositive = a.positive;
 
-    var out = <Polygon>[null];
+    var out = <Polygon?>[null];
 
     for (var i = 1; i < results.length; i++) {
       var poly = results[i];
@@ -378,12 +378,17 @@ OperationResult _operation(Polygon a, Polygon b, bool union) {
     out[0] = withoutDoubles(
         Polygon(points: results.first, positive: firstIsPositive));
 
-    return OperationResultTransform(out..removeWhere((p) => p == null));
+    return OperationResultTransform(out.withoutNulls);
   } else {
     return OperationResultTransform(results
         .map((ps) => withoutDoubles(Polygon(points: ps, positive: a.positive)))
-        .where((p) => p != null));
+        .withoutNulls);
   }
+}
+
+extension NullIterableExtension<T> on Iterable<T?> {
+  Iterable<T> get withoutNulls =>
+      this.where((element) => element != null) as Iterable<T>;
 }
 
 void _dilate(
@@ -405,9 +410,9 @@ void _dilate(
 }
 
 abstract class OperationResult {
-  final Iterable<Polygon> output;
+  final List<Polygon> output;
 
-  OperationResult(this.output);
+  OperationResult(Iterable<Polygon> output) : this.output = output.toList();
 
   String get name;
 
@@ -432,7 +437,8 @@ class OperationResultNoOverlap extends OperationResult {
 class OperationResultContain extends OperationResultNoOverlap {
   final Polygon container;
 
-  OperationResultContain(List<Polygon> result, this.container) : super(result);
+  OperationResultContain(Iterable<Polygon> result, this.container)
+      : super(result);
 
   @override
   String get name =>
@@ -487,7 +493,7 @@ List<List<Point<int>>> _splitSelfIntersections(List<Point<int>> points) {
 
 /// Removes every point preceded by another point with the same coordinates
 /// and forces `polygon`s list of points not to repeat.
-Polygon withoutDoubles(Polygon polygon) {
+Polygon? withoutDoubles(Polygon polygon) {
   final points = removeDoubles(polygon.points);
   if (points == null) return null;
 
@@ -496,7 +502,7 @@ Polygon withoutDoubles(Polygon polygon) {
 
 /// Returns a copy of `points` where every point preceded by another point with
 /// the same coordinates is removed.
-List<Point<int>> removeDoubles(List<Point<int>> points) {
+List<Point<int>>? removeDoubles(List<Point<int>> points) {
   var first = points.first;
   var second = points.elementAt(1);
   var previous = first;
@@ -572,16 +578,16 @@ Polygon upscale(Polygon poly, int m) {
 }
 
 class PolygonMerger {
-  Map<Polygon, Polygon> _parents;
-  void Function(Polygon polygon) onRemove;
-  void Function(Polygon polygon, Polygon parent) onAdd;
-  void Function(Polygon polygon, Polygon parent) onUpdateParent;
+  late Map<Polygon, Polygon?> _parents;
+  void Function(Polygon polygon)? onRemove;
+  void Function(Polygon polygon, Polygon? parent)? onAdd;
+  void Function(Polygon polygon, Polygon? parent)? onUpdateParent;
 
   PolygonMerger({this.onAdd, this.onRemove, this.onUpdateParent});
 
   void _remove(Polygon p) {
     _parents.remove(p);
-    if (onRemove != null) onRemove(p);
+    if (onRemove != null) onRemove!(p);
   }
 
   void _removeHPoly(HPolygon hp) {
@@ -591,14 +597,14 @@ class PolygonMerger {
     _remove(hp.polygon);
   }
 
-  void _setParent(Polygon p, Polygon parent) {
+  void _setParent(Polygon p, Polygon? parent) {
     _parents[p] = parent;
-    if (onUpdateParent != null) onUpdateParent(p, parent);
+    if (onUpdateParent != null) onUpdateParent!(p, parent);
   }
 
-  void _add(Polygon p, Polygon parent) {
+  void _add(Polygon p, Polygon? parent) {
     _parents[p] = parent;
-    if (onAdd != null) onAdd(p, parent);
+    if (onAdd != null) onAdd!(p, parent);
   }
 
   List<Polygon> _findChildren(Polygon p) {
@@ -690,8 +696,8 @@ class PolygonMerger {
 
     bool samePole = polygon.positive; // Hierarchy roots must be positive
     Map<Polygon, List<Polygon>> parentSame = {};
-    HPolygon parentDiff;
-    Polygon lastContainer;
+    HPolygon? parentDiff;
+    Polygon? lastContainer;
     bool makeBridge = false;
     bool isectAny = false;
     Polygon layerPoly;
@@ -701,7 +707,7 @@ class PolygonMerger {
       Set<HPolygon> nextLayer = {};
       Set<HPolygon> mergeIntoParent = {};
       final nParentSame = <Polygon, List<Polygon>>{};
-      Polygon parent;
+      Polygon? parent;
       Set<Polygon> nHoles = {};
 
       for (var other in layer) {
@@ -752,7 +758,7 @@ class PolygonMerger {
           nextLayer.addAll(other.children);
           if (samePole) {
             if (makeBridge) {
-              final parents = parentSame[other.polygon] ?? [parent];
+              final parents = parentSame[other.polygon] ?? [parent!];
               _makeBridge(other, parents, parentSame, nParentSame);
 
               parent = null;
@@ -813,7 +819,7 @@ class PolygonMerger {
             for (var remove in holeReplacements.keys) {
               var add = holeReplacements[remove];
               nHoles.remove(remove);
-              nHoles.addAll(add);
+              nHoles.addAll(add ?? const []);
             }
           }
         }

--- a/lib/math/rasterize.dart
+++ b/lib/math/rasterize.dart
@@ -124,13 +124,17 @@ List<Polygon> _squareGridPolyFromBitmap(
   List<List<bool>> solid,
   TiledGrid grid,
   bool positive, [
-  Point<int> offset,
-  Set<Point<int>> visited,
+  Point<int>? offset,
+  Set<Point<int>>? visited,
 ]) {
   visited ??= {};
 
-  Point<int> initial = _findFirstSolid2d(solid, offset, visited);
-  if (initial == null) return [];
+  late Point<int> initial;
+  try {
+    initial = _findFirstSolid2d(solid, offset, visited);
+  } catch (err) {
+    return [];
+  }
 
   Point<int> scale(Point<int> q) {
     return grid.gridToWorldSpace(mapZero + q).round();
@@ -214,8 +218,8 @@ List<Polygon> _squareGridPolyFromBitmap(
 
 Point<int> _findFirstSolid2d(
   List<List<bool>> solid, [
-  Point<int> start,
-  Set<Point<int>> visited,
+  Point<int>? start,
+  Set<Point<int>>? visited,
 ]) {
   bool inside = start != null;
   int rowStart = start?.x ?? 0;
@@ -224,7 +228,7 @@ Point<int> _findFirstSolid2d(
       if (!inside) {
         if (solid[y][x]) {
           final point = Point(x, y);
-          if (!visited.contains(point)) {
+          if (visited != null && !visited.contains(point)) {
             return point;
           } else {
             inside = true;
@@ -237,5 +241,5 @@ Point<int> _findFirstSolid2d(
     rowStart = 0;
   }
 
-  return null;
+  throw 'Unable to find any solid cell in grid';
 }

--- a/lib/polygon_canvas.dart
+++ b/lib/polygon_canvas.dart
@@ -16,7 +16,7 @@ import 'math/polymath.dart';
 import 'polygon_canvas_data.dart';
 
 class PolygonCanvas with CanvasLoader, PolygonToolbox {
-  Grid grid = Grid.square(1, size: Point(50.5, 50.5));
+  Grid grid = Grid.unclamped();
   PolygonState state = PolygonState({});
   late PolygonMerger _merger;
   final _svg = <Polygon, SvgPolygon>{};
@@ -359,7 +359,8 @@ class PolygonCanvas with CanvasLoader, PolygonToolbox {
           maker.isClicked = click;
           maker.movementScale = movementScale;
 
-          activePath = activeTool.createNewPath(maker)..handleStart(eventP);
+          activePath = activeTool.createNewPath(maker);
+          activePath!.handleStart(eventP);
 
           moveStreamCtrl = StreamController();
           moveStreamCtrl!.stream.listen((point) async {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,493 +5,570 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      url: "https://pub.dartlang.org"
+      sha256: "0816708f5fbcacca324d811297153fe3c8e047beb5c6752e12292d2974c17045"
+      url: "https://pub.dev"
     source: hosted
-    version: "51.0.0"
+    version: "62.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      url: "https://pub.dartlang.org"
+      sha256: "21862995c9932cd082f89d72ae5f5e2c110d1a0204ad06e4ebaee8307b76b834"
+      url: "https://pub.dev"
     source: hosted
-    version: "5.3.1"
+    version: "6.0.0"
   archive:
     dependency: transitive
     description:
       name: archive
-      url: "https://pub.dartlang.org"
+      sha256: "0c8368c9b3f0abbc193b9d6133649a614204b528982bebc7026372d61677ce3a"
+      url: "https://pub.dev"
     source: hosted
-    version: "3.3.5"
+    version: "3.3.7"
   args:
     dependency: transitive
     description:
       name: args
-      url: "https://pub.dartlang.org"
+      sha256: eef6c46b622e0494a36c5a12d10d77fb4e855501a91c1b9ef9339326e58f0596
+      url: "https://pub.dev"
     source: hosted
-    version: "2.3.1"
+    version: "2.4.2"
   async:
     dependency: transitive
     description:
       name: async
-      url: "https://pub.dartlang.org"
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.10.0"
+    version: "2.11.0"
   bazel_worker:
     dependency: transitive
     description:
       name: bazel_worker
-      url: "https://pub.dartlang.org"
+      sha256: "6aa1de567844e1a1db3ac16959159b31a71128fdd27d63d861ad5aa7299e48c5"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.3"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      url: "https://pub.dartlang.org"
+      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
   build:
     dependency: transitive
     description:
       name: build
-      url: "https://pub.dartlang.org"
+      sha256: "80184af8b6cb3e5c1c4ec6d8544d27711700bc3e6d2efad04238c7b5290889f0"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.3.1"
+    version: "2.4.1"
   build_config:
     dependency: transitive
     description:
       name: build_config
-      url: "https://pub.dartlang.org"
+      sha256: bf80fcfb46a29945b423bd9aad884590fb1dc69b330a4d4700cac476af1708d1
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
   build_daemon:
     dependency: transitive
     description:
       name: build_daemon
-      url: "https://pub.dartlang.org"
+      sha256: "5f02d73eb2ba16483e693f80bee4f088563a820e47d1027d4cdfe62b5bb43e65"
+      url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "4.0.0"
   build_modules:
     dependency: transitive
     description:
       name: build_modules
-      url: "https://pub.dartlang.org"
+      sha256: "409fc1be491612bc1e2262f4c7fec6c91c683560662a34cfeedfcd1f7c13470b"
+      url: "https://pub.dev"
     source: hosted
-    version: "4.0.7"
+    version: "5.0.3"
   build_resolvers:
     dependency: transitive
     description:
       name: build_resolvers
-      url: "https://pub.dartlang.org"
+      sha256: "6c4dd11d05d056e76320b828a1db0fc01ccd376922526f8e9d6c796a5adbac20"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.2.1"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      url: "https://pub.dartlang.org"
+      sha256: "10c6bcdbf9d049a0b666702cf1cee4ddfdc38f02a19d35ae392863b47519848b"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.3.3"
+    version: "2.4.6"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
-      url: "https://pub.dartlang.org"
+      sha256: "6d6ee4276b1c5f34f21fdf39425202712d2be82019983d52f351c94aafbc2c41"
+      url: "https://pub.dev"
     source: hosted
-    version: "7.2.7"
+    version: "7.2.10"
   build_web_compilers:
     dependency: "direct dev"
     description:
       name: build_web_compilers
-      url: "https://pub.dartlang.org"
+      sha256: "544333e7f16eddc6f260c426ba8ea5a8fdf1809acc555b2c1c8c8446d1b61ea7"
+      url: "https://pub.dev"
     source: hosted
-    version: "3.2.7"
+    version: "4.0.4"
   built_collection:
     dependency: transitive
     description:
       name: built_collection
-      url: "https://pub.dartlang.org"
+      sha256: "376e3dd27b51ea877c28d525560790aee2e6fbb5f20e2f85d5081027d94e2100"
+      url: "https://pub.dev"
     source: hosted
     version: "5.1.1"
   built_value:
     dependency: transitive
     description:
       name: built_value
-      url: "https://pub.dartlang.org"
+      sha256: "598a2a682e2a7a90f08ba39c0aaa9374c5112340f0a2e275f61b59389543d166"
+      url: "https://pub.dev"
     source: hosted
-    version: "8.4.2"
+    version: "8.6.1"
   checked_yaml:
     dependency: transitive
     description:
       name: checked_yaml
-      url: "https://pub.dartlang.org"
+      sha256: feb6bed21949061731a7a75fc5d2aa727cf160b91af9a3e464c5e3a32e28b5ff
+      url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.3"
   code_builder:
     dependency: transitive
     description:
       name: code_builder
-      url: "https://pub.dartlang.org"
+      sha256: "4ad01d6e56db961d29661561effde45e519939fdaeb46c351275b182eac70189"
+      url: "https://pub.dev"
     source: hosted
-    version: "4.3.0"
+    version: "4.5.0"
   collection:
     dependency: transitive
     description:
       name: collection
-      url: "https://pub.dartlang.org"
+      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
+      url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.17.2"
   convert:
     dependency: transitive
     description:
       name: convert
-      url: "https://pub.dartlang.org"
+      sha256: "0f08b14755d163f6e2134cb58222dd25ea2a2ee8a195e53983d57c075324d592"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.1"
   coverage:
     dependency: transitive
     description:
       name: coverage
-      url: "https://pub.dartlang.org"
+      sha256: "2fb815080e44a09b85e0f2ca8a820b15053982b2e714b59267719e8a9ff17097"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.6.1"
+    version: "1.6.3"
   crypto:
     dependency: transitive
     description:
       name: crypto
-      url: "https://pub.dartlang.org"
+      sha256: ff625774173754681d66daaf4a448684fb04b78f902da9cb3d308c19cc5e8bab
+      url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "3.0.3"
+  dart_internal:
+    dependency: transitive
+    description:
+      name: dart_internal
+      sha256: dae3976f383beddcfcd07ad5291a422df2c8c0a8a03c52cda63ac7b4f26e0f4e
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.8"
   dart_style:
     dependency: transitive
     description:
       name: dart_style
-      url: "https://pub.dartlang.org"
+      sha256: "1efa911ca7086affd35f463ca2fc1799584fb6aa89883cf0af8e3664d6a02d55"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.2.4"
+    version: "2.3.2"
   file:
     dependency: transitive
     description:
       name: file
-      url: "https://pub.dartlang.org"
+      sha256: "5fc22d7c25582e38ad9a8515372cd9a93834027aacf1801cf01164dac0ffa08c"
+      url: "https://pub.dev"
     source: hosted
-    version: "6.1.4"
+    version: "7.0.0"
   fixnum:
     dependency: transitive
     description:
       name: fixnum
-      url: "https://pub.dartlang.org"
+      sha256: "25517a4deb0c03aa0f32fd12db525856438902d9c16536311e76cdc57b31d7d1"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.1"
+    version: "1.1.0"
   frontend_server_client:
     dependency: transitive
     description:
       name: frontend_server_client
-      url: "https://pub.dartlang.org"
+      sha256: "408e3ca148b31c20282ad6f37ebfa6f4bdc8fede5b74bc2f08d9d92b55db3612"
+      url: "https://pub.dev"
     source: hosted
     version: "3.2.0"
   glob:
     dependency: transitive
     description:
       name: glob
-      url: "https://pub.dartlang.org"
+      sha256: "0e7014b3b7d4dac1ca4d6114f82bf1782ee86745b9b42a92c9289c23d8a0ab63"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   graphs:
     dependency: transitive
     description:
       name: graphs
-      url: "https://pub.dartlang.org"
+      sha256: aedc5a15e78fc65a6e23bcd927f24c64dd995062bcd1ca6eda65a3cff92a4d19
+      url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.3.1"
   grid_space:
     dependency: "direct main"
     description:
       path: "."
       ref: HEAD
-      resolved-ref: "83d68962665e9e1f74815e8e1bae99741bc168f2"
+      resolved-ref: "0574a8cb9dcddd55ef9867eb9e94224b6468d94a"
       url: "https://github.com/doodlezucc/dart_grid_space.git"
     source: git
-    version: "1.0.0"
+    version: "1.0.1"
   http_multi_server:
     dependency: transitive
     description:
       name: http_multi_server
-      url: "https://pub.dartlang.org"
+      sha256: "97486f20f9c2f7be8f514851703d0119c3596d14ea63227af6f7a481ef2b2f8b"
+      url: "https://pub.dev"
     source: hosted
     version: "3.2.1"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
-      url: "https://pub.dartlang.org"
+      sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
+      url: "https://pub.dev"
     source: hosted
     version: "4.0.2"
   io:
     dependency: transitive
     description:
       name: io
-      url: "https://pub.dartlang.org"
+      sha256: "2ec25704aba361659e10e3e5f5d672068d332fc8ac516421d483a11e5cbd061e"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.3"
+    version: "1.0.4"
   js:
     dependency: transitive
     description:
       name: js
-      url: "https://pub.dartlang.org"
+      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
+      url: "https://pub.dev"
     source: hosted
-    version: "0.6.5"
+    version: "0.6.7"
   json_annotation:
     dependency: transitive
     description:
       name: json_annotation
-      url: "https://pub.dartlang.org"
+      sha256: b10a7b2ff83d83c777edba3c6a0f97045ddadd56c944e1a23a3fdf43a1bf4467
+      url: "https://pub.dev"
     source: hosted
-    version: "4.7.0"
+    version: "4.8.1"
   logging:
     dependency: transitive
     description:
       name: logging
-      url: "https://pub.dartlang.org"
+      sha256: "623a88c9594aa774443aa3eb2d41807a48486b5613e67599fb4c41c0ad47c340"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      url: "https://pub.dartlang.org"
+      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.12.14"
+    version: "0.12.16"
   meta:
     dependency: transitive
     description:
       name: meta
-      url: "https://pub.dartlang.org"
+      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.9.1"
   mime:
     dependency: transitive
     description:
       name: mime
-      url: "https://pub.dartlang.org"
+      sha256: e4ff8e8564c03f255408decd16e7899da1733852a9110a58fe6d1b817684a63e
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.3"
+    version: "1.0.4"
   node_preamble:
     dependency: transitive
     description:
       name: node_preamble
-      url: "https://pub.dartlang.org"
+      sha256: "6e7eac89047ab8a8d26cf16127b5ed26de65209847630400f9aefd7cd5c730db"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.2"
   package_config:
     dependency: transitive
     description:
       name: package_config
-      url: "https://pub.dartlang.org"
+      sha256: "1c5b77ccc91e4823a5af61ee74e6b972db1ef98c2ff5a18d3161c982a55448bd"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
   path:
     dependency: transitive
     description:
       name: path
-      url: "https://pub.dartlang.org"
+      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      url: "https://pub.dev"
     source: hosted
     version: "1.8.3"
   pointycastle:
     dependency: transitive
     description:
       name: pointycastle
-      url: "https://pub.dartlang.org"
+      sha256: "7c1e5f0d23c9016c5bbd8b1473d0d3fb3fc851b876046039509e18e0c7485f2c"
+      url: "https://pub.dev"
     source: hosted
-    version: "3.6.2"
+    version: "3.7.3"
   pool:
     dependency: transitive
     description:
       name: pool
-      url: "https://pub.dartlang.org"
+      sha256: "20fe868b6314b322ea036ba325e6fc0711a22948856475e2c2b6306e8ab39c2a"
+      url: "https://pub.dev"
     source: hosted
     version: "1.5.1"
   protobuf:
     dependency: transitive
     description:
       name: protobuf
-      url: "https://pub.dartlang.org"
+      sha256: "4034a02b7e231e7e60bff30a8ac13a7347abfdac0798595fae0b90a3f0afe759"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "3.0.0"
   pub_semver:
     dependency: transitive
     description:
       name: pub_semver
-      url: "https://pub.dartlang.org"
+      sha256: "40d3ab1bbd474c4c2328c91e3a7df8c6dd629b79ece4c4bd04bee496a224fb0c"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.3"
+    version: "2.1.4"
   pubspec_parse:
     dependency: transitive
     description:
       name: pubspec_parse
-      url: "https://pub.dartlang.org"
+      sha256: c63b2876e58e194e4b0828fcb080ad0e06d051cb607a6be51a9e084f47cb9367
+      url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.3"
   scratch_space:
     dependency: transitive
     description:
       name: scratch_space
-      url: "https://pub.dartlang.org"
+      sha256: "8510fbff458d733a58fc427057d1ac86303b376d609d6e1bc43f240aad9aa445"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.1"
+    version: "1.0.2"
   shelf:
     dependency: transitive
     description:
       name: shelf
-      url: "https://pub.dartlang.org"
+      sha256: ad29c505aee705f41a4d8963641f91ac4cee3c8fad5947e033390a7bd8180fa4
+      url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   shelf_packages_handler:
     dependency: transitive
     description:
       name: shelf_packages_handler
-      url: "https://pub.dartlang.org"
+      sha256: "89f967eca29607c933ba9571d838be31d67f53f6e4ee15147d5dc2934fee1b1e"
+      url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   shelf_static:
     dependency: transitive
     description:
       name: shelf_static
-      url: "https://pub.dartlang.org"
+      sha256: a41d3f53c4adf0f57480578c1d61d90342cd617de7fc8077b1304643c2d85c1e
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
-      url: "https://pub.dartlang.org"
+      sha256: "9ca081be41c60190ebcb4766b2486a7d50261db7bd0f5d9615f2d653637a84c1"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.3"
+    version: "1.0.4"
   source_map_stack_trace:
     dependency: transitive
     description:
       name: source_map_stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: "84cf769ad83aa6bb61e0aa5a18e53aea683395f196a6f39c4c881fb90ed4f7ae"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
   source_maps:
     dependency: transitive
     description:
       name: source_maps
-      url: "https://pub.dartlang.org"
+      sha256: "708b3f6b97248e5781f493b765c3337db11c5d2c81c3094f10904bfa8004c703"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.10.11"
+    version: "0.10.12"
   source_span:
     dependency: transitive
     description:
       name: source_span
-      url: "https://pub.dartlang.org"
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.10.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.11.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      url: "https://pub.dartlang.org"
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   stream_transform:
     dependency: transitive
     description:
       name: stream_transform
-      url: "https://pub.dartlang.org"
+      sha256: "14a00e794c7c11aa145a170587321aedce29769c08d7f58b1d141da75e3b1c6f"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      url: "https://pub.dartlang.org"
+      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      url: "https://pub.dartlang.org"
+      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
   test:
     dependency: "direct dev"
     description:
       name: test
-      url: "https://pub.dartlang.org"
+      sha256: "67ec5684c7a19b2aba91d2831f3d305a6fd8e1504629c5818f8d64478abf4f38"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.22.1"
+    version: "1.24.4"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      url: "https://pub.dartlang.org"
+      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.4.17"
+    version: "0.6.1"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      url: "https://pub.dartlang.org"
+      sha256: "6b753899253c38ca0523bb0eccff3934ec83d011705dae717c61ecf209e333c9"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.4.21"
+    version: "0.5.4"
   timing:
     dependency: transitive
     description:
       name: timing
-      url: "https://pub.dartlang.org"
+      sha256: "70a3b636575d4163c477e6de42f247a23b315ae20e86442bebe32d3cabf61c32"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.1"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
-      url: "https://pub.dartlang.org"
+      sha256: facc8d6582f16042dd49f2463ff1bd6e2c9ef9f3d5da3d9b087e244a7b564b3c
+      url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.2"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
-      url: "https://pub.dartlang.org"
+      sha256: ada49637c27973c183dad90beb6bd781eea4c9f5f955d35da172de0af7bd3440
+      url: "https://pub.dev"
     source: hosted
-    version: "9.4.0"
+    version: "11.8.0"
   watcher:
     dependency: transitive
     description:
       name: watcher
-      url: "https://pub.dartlang.org"
+      sha256: "3d2ad6751b3c16cf07c7fca317a1413b3f26530319181b37e3b9039b84fc01d8"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.2"
+    version: "1.1.0"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
-      url: "https://pub.dartlang.org"
+      sha256: d88238e5eac9a42bb43ca4e721edba3c08c6354d4a53063afaa568516217621b
+      url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.4.0"
   webkit_inspection_protocol:
     dependency: transitive
     description:
       name: webkit_inspection_protocol
-      url: "https://pub.dartlang.org"
+      sha256: "67d3a8b6c79e1987d19d848b0892e582dbb0c66c57cc1fef58a177dd2aa2823d"
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
   yaml:
     dependency: transitive
     description:
       name: yaml
-      url: "https://pub.dartlang.org"
+      sha256: "75769501ea3489fca56601ff33454fe45507ea3bfb014161abc3b43ae25989d5"
+      url: "https://pub.dev"
     source: hosted
-    version: "3.1.1"
+    version: "3.1.2"
 sdks:
-  dart: ">=2.18.0 <3.0.0"
+  dart: ">=3.0.0 <3.2.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: web_polymask
 description: A polygon merging library with web/svg implementation.
-version: 1.0.0
+version: 1.1.0
 publish_to: none
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 publish_to: none
 
 environment:
-  sdk: ">=2.10.0 <3.0.0"
+  sdk: ">=2.12.0 <4.0.0"
 
 dependencies:
   grid_space:
@@ -12,5 +12,5 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.1.7
-  build_web_compilers: ^3.2.2
+  build_web_compilers: ^4.0.4
   test: ^1.17.8

--- a/test/ring_search.dart
+++ b/test/ring_search.dart
@@ -7,14 +7,14 @@ class RingSearchError<T> {
   RingSearchError(this.ring, this.other, this.errorInRing, this.offset);
 }
 
-RingSearchError<T> ringMismatch<T>(List<T> ring, List<T> other) {
+RingSearchError<T>? ringMismatch<T>(List<T> ring, List<T> other) {
   if (ring.isEmpty) return null;
 
   RingSearchError<T> lastError = RingSearchError(ring, other, 0, 0);
 
   var offset = -1;
   while ((offset = other.indexOf(ring[0], offset + 1)) >= 0) {
-    RingSearchError<T> error;
+    RingSearchError<T>? error;
 
     for (var i = 0; i < ring.length; i++) {
       final item = ring[i];

--- a/test/test_helpers.dart
+++ b/test/test_helpers.dart
@@ -31,7 +31,7 @@ final polygonRegex = RegExp(r'\((\w+), (.*?)\)');
 Set<Polygon> parseState(String s) {
   return polygonRegex
       .allMatches(s)
-      .map((m) => Polygon(positive: m[1] == 'positive', points: parse(m[2])))
+      .map((m) => Polygon(positive: m[1] == 'positive', points: parse(m[2]!)))
       .toSet();
 }
 
@@ -122,8 +122,10 @@ abstract class HierarchyMatcher<T, M> extends Matcher {
     String out = '';
     String d = '  ' * depth;
 
-    if (miscount[siblings] != null) {
-      int actualCount = miscount[siblings];
+    final siblingMiscount = miscount[siblings];
+
+    if (siblingMiscount != null) {
+      int actualCount = siblingMiscount;
       final children = actualCount == 1 ? 'CHILD' : 'CHILDREN';
       out += '\n${d}HAS $actualCount $children INSTEAD OF ${siblings.length}:';
     }
@@ -226,10 +228,10 @@ class StateMatcher extends HierarchyMatcher<HPolygon, Polygon> {
 }
 
 Matcher polygonMatchInstance(
-  Polygon expected, {
+  Polygon? expected, {
   bool requireSimple = true,
   bool checkOrder = true,
-  Map map,
+  Map? map,
 }) {
   if (expected == null) return isNull;
   forceClockwise(expected);
@@ -246,8 +248,8 @@ Matcher polygonMatch(
   List<Point<int>> points, {
   bool requireSimple = true,
   bool checkOrder = true,
-  bool positive,
-  Map map,
+  bool? positive,
+  Map? map,
 }) {
   var matcher = TypeMatcher<Polygon>();
 
@@ -267,7 +269,7 @@ Matcher polygonMatch(
 }
 
 class PolygonOperationMatcher extends TypeMatcher<Iterable<Polygon>> {
-  Matcher _matcher;
+  late Matcher _matcher;
   final Iterable<Polygon> expected;
   final Map errorMap = {};
 
@@ -335,22 +337,22 @@ class PolygonOperationMatcher extends TypeMatcher<Iterable<Polygon>> {
   }
 }
 
-Matcher ringMatch<S>(List<S> ring, {Map map}) =>
+Matcher ringMatch<S>(List<S> ring, {Map? map}) =>
     allOf(hasLength(ring.length), _RingMatcher<S>(ring, map));
 
 class _RingMatcher<S> extends TypeMatcher<List<S>> {
-  final Map map;
+  final Map? map;
   final List<S> ring;
 
   _RingMatcher(this.ring, this.map);
 
   @override
-  bool matches(Object other, Map matchState) {
+  bool matches(Object? other, Map matchState) {
     if (other is List<S>) {
       final error = ringMismatch(ring, other);
       if (error == null) return true;
 
-      if (map != null) map[other] = error;
+      if (map != null) map![other] = error;
     }
 
     return false;

--- a/web/main.dart
+++ b/web/main.dart
@@ -1,11 +1,12 @@
 import 'dart:html';
 import 'dart:js_util';
+import 'dart:svg';
 
 import 'package:web_polymask/polygon_canvas.dart';
 
 void main() {
   var canvas = PolygonCanvas(
-    querySelector('svg'),
+    querySelector('svg') as SvgSvgElement,
     acceptStartEvent: (ev) => (ev is MouseEvent) && ev.button == 0,
     cropMargin: 40,
   );
@@ -39,13 +40,13 @@ void main() {
 }
 
 void _resizeMask() async {
-  var clientRect = querySelector('svg').getBoundingClientRect();
+  var clientRect = querySelector('svg')!.getBoundingClientRect();
 
   if (clientRect.width == 0) {
     return Future.delayed(Duration(milliseconds: 20), _resizeMask);
   }
 
-  querySelector('#polynegmask rect').attributes.addAll({
+  querySelector('#polynegmask rect')!.attributes.addAll({
     'width': '${clientRect.width}',
     'height': '${clientRect.height}',
   });


### PR DESCRIPTION
With the Dart 3.0 release, null safety is required. That's why I'm finally bumping the minimum SDK version to `2.12.0` (which introduced null safety and is therefore the lowest possible version with forward compatibility).